### PR TITLE
Fixing issues raised on code review

### DIFF
--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTaskIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTaskIT.java
@@ -32,8 +32,8 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.runtime.WorkerSinkTaskContext;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.apache.kafka.test.TestUtils;
 
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
@@ -132,7 +132,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
 
         final var opensearchSinkTask = new OpensearchSinkTask();
         try {
-            final var mockContext = mock(WorkerSinkTaskContext.class);
+            final var mockContext = mock(SinkTaskContext.class);
             opensearchSinkTask.initialize(mockContext);
             opensearchSinkTask.start(getDefaultTaskProperties(true, RecordConverter.BehaviorOnNullValues.DEFAULT));
             opensearchSinkTask.put(
@@ -354,7 +354,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
 
     private void runTask(final Map<String, String> props, final List<SinkRecord> records) {
         final var opensearchSinkTask = new OpensearchSinkTask();
-        final var mockContext = mock(WorkerSinkTaskContext.class);
+        final var mockContext = mock(SinkTaskContext.class);
         opensearchSinkTask.initialize(mockContext);
         try {
             opensearchSinkTask.start(props);

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTask.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTask.java
@@ -30,6 +30,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
 
@@ -74,13 +75,21 @@ public class OpensearchSinkTask extends SinkTask {
                         TimeUnit.MILLISECONDS.toHours(maxRetryBackoffMs));
             }
 
-            this.client = new OpensearchClient(config, context.errantRecordReporter());
+            this.client = new OpensearchClient(config, getErrantRecordReporter());
             this.recordConverter = new RecordConverter(config);
         } catch (final ConfigException e) {
             throw new ConnectException(
                     "Couldn't start OpensearchSinkTask due to configuration error:",
                     e
             );
+        }
+    }
+
+    private ErrantRecordReporter getErrantRecordReporter() {
+        try {
+            return context.errantRecordReporter();
+        } catch (NoSuchMethodError | NoClassDefFoundError e) {
+            return null;
         }
     }
 


### PR DESCRIPTION
Main changes:
1. Report to DLQ only after completing all retry cycles. Note that in case of an "aborted" failure, the records will be reported to DLQ but an exception will be thrown as today and the connector will stop.
2. Handle class loading issues that might happen when using older version of kafka-connect (errantRecordReporter is supported only starting from 2.6). Note that context.errantRecordReporter() will return null in case no dead letter queue is configured, and in this case nothing will be reported to DLQ.
3. Additional minor fixes based on comments.