### PR TITLE
do not report to dlq in case 'errors.tolerance' is none and the error…

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -289,7 +289,7 @@
 
         <!-- See http://checkstyle.sourceforge.net/config_metrics.html#ClassFanOutComplexity -->
         <module name="ClassFanOutComplexity">
-            <property name="max" value="22"/>
+            <property name="max" value="23"/>
             <property name="excludedPackages" value="java.io,java.util,org.slf4j"/>
         </module>
 

--- a/src/main/java/io/aiven/kafka/connect/opensearch/BulkProcessor.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/BulkProcessor.java
@@ -127,7 +127,7 @@ public class BulkProcessor {
                 BehaviorOnMalformedDoc.WARN);
         }
 
-        if (reporter != null && this.errorToleranceType.equals(ErrorToleranceType.NONE)
+        if (reporter != null && this.errorToleranceType == ErrorToleranceType.NONE
                 && (config.behaviorOnMalformedDoc() != BehaviorOnMalformedDoc.FAIL
                 || config.behaviorOnVersionConflict() != BehaviorOnVersionConflict.FAIL)) {
             LOGGER.warn("The '{}' is set to `{}`, which means that only errors that would cause the task to fail"

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfig.java
@@ -153,6 +153,11 @@ public class OpensearchSinkConnectorConfig extends AbstractConfig {
             + "Opensearch rejects due to version conflicts (if optimistic locking mechanism has been"
             + "activated). Valid options are 'ignore', 'warn', and 'fail'.";
 
+    public static final String ERRORS_TOLERANCE_CONFIG = "errors.tolerance";
+    public static final String ERRORS_TOLERANCE_DOC = "Behavior for tolerating errors during connector operation. "
+        + "'none' is the default value and signals that any error will result in an immediate connector task failure;"
+        + " 'all' changes the behavior to skip over problematic records.";
+
     protected static ConfigDef baseConfigDef() {
         final ConfigDef configDef = new ConfigDef();
         addConnectorConfigs(configDef);
@@ -397,7 +402,18 @@ public class OpensearchSinkConnectorConfig extends AbstractConfig {
                 group,
                 ++order,
                 Width.SHORT,
-                "Behavior on document's version conflict (optimistic locking)");
+                "Behavior on document's version conflict (optimistic locking)"
+        ).define(
+                ERRORS_TOLERANCE_CONFIG,
+                Type.STRING,
+                BulkProcessor.ErrorToleranceType.DEFAULT.toString(),
+                BulkProcessor.ErrorToleranceType.VALIDATOR,
+                Importance.LOW,
+                ERRORS_TOLERANCE_DOC,
+                group,
+                ++order,
+                Width.SHORT,
+                "Error Tolerance");
     }
 
     public static final ConfigDef CONFIG = baseConfigDef();
@@ -518,6 +534,12 @@ public class OpensearchSinkConnectorConfig extends AbstractConfig {
     public BulkProcessor.BehaviorOnVersionConflict behaviorOnVersionConflict() {
         return BulkProcessor.BehaviorOnVersionConflict.forValue(
                 getString(OpensearchSinkConnectorConfig.BEHAVIOR_ON_VERSION_CONFLICT_CONFIG)
+        );
+    }
+
+    public BulkProcessor.ErrorToleranceType errorToleranceType() {
+        return BulkProcessor.ErrorToleranceType.forValue(
+                getString(OpensearchSinkConnectorConfig.ERRORS_TOLERANCE_CONFIG)
         );
     }
 


### PR DESCRIPTION
… wouldn't cause the task to fail, since reporter::report will fail the task after reporting, unless 'errors.tolerance' is 'all'.